### PR TITLE
Run Symfony in production mode

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+APP_ENV=prod
 APP_SECRET=b00172a53597d40245b66d2c158b9988
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^localhost|example\.com$'


### PR DESCRIPTION
`dev` is only intended for local development. In production and in benchmarks, we should use `prod`. Thanks.